### PR TITLE
Skipping past stories with undefined url and title

### DIFF
--- a/src/provider/pocket.ts
+++ b/src/provider/pocket.ts
@@ -239,6 +239,10 @@ export default class PocketProvider {
         };
         const stories = await this.getStories(combinedSearchParams);
         for (const story of stories) {
+          if (story.url === undefined || story.title === undefined) {
+              console.warn("WARN: Skipping story due to undefined url or title:", story);
+              continue; // Skip this iteration
+          }
           feed.addArticleAcquisitionEntry(story.url, story.title);
         }
         res.type('application/xml').send(feed.toXmlString());
@@ -267,6 +271,10 @@ export default class PocketProvider {
           };
           const stories = await this.getStories(combinedSearchParams);
           for (const story of stories) {
+            if (story.url === undefined || story.title === undefined) {
+                console.warn("WARN: Skipping story due to undefined url or title:", story);
+                continue; // Skip this iteration
+            }
             feed.addArticleAcquisitionEntry(story.url, story.title);
           }
           res.type('application/xml').send(feed.toXmlString());


### PR DESCRIPTION
I started getting 502s from using this recently, and reading the stack trace found that Pocket was sometimes returning `story` objects with no `title` or `resolved_url` fields, just an `id`. No idea why, but all it takes is one bad story and the whole catalog becomes unusable. Adding this check to skip over problematic stories fixes this.